### PR TITLE
Add nil checks for RefName and RepositoryName in conditions processing

### DIFF
--- a/internal/utils/exportruleset.go
+++ b/internal/utils/exportruleset.go
@@ -79,8 +79,10 @@ func ProcessConditions(ruleset data.RepoRuleset) data.ProcessedConditions {
 			PropertyInclude = ProcessProperties(ruleset.Conditions.RepositoryProperty.Include)
 			PropertyExclude = ProcessProperties(ruleset.Conditions.RepositoryProperty.Exclude)
 		}
-		includeRefNames = strings.Join(ruleset.Conditions.RefName.Include, ";")
-		excludeRefNames = strings.Join(ruleset.Conditions.RefName.Exclude, ";")
+		if ruleset.Conditions.RefName != nil {
+			includeRefNames = strings.Join(ruleset.Conditions.RefName.Include, ";")
+			excludeRefNames = strings.Join(ruleset.Conditions.RefName.Exclude, ";")
+		}
 	}
 	return data.ProcessedConditions{
 		IncludeNames:    includeNames,

--- a/internal/utils/importruleset.go
+++ b/internal/utils/importruleset.go
@@ -109,10 +109,14 @@ func (g *APIGetter) parseRules(owner string, headerMap []string, ruleValues []st
 }
 
 func CleanConditions(conditions *data.Conditions) *data.Conditions {
-	conditions.RefName.Include = CleanSlice(conditions.RefName.Include)
-	conditions.RefName.Exclude = CleanSlice(conditions.RefName.Exclude)
-	conditions.RepositoryName.Include = CleanSlice(conditions.RepositoryName.Include)
-	conditions.RepositoryName.Exclude = CleanSlice(conditions.RepositoryName.Exclude)
+	if conditions.RefName != nil {
+		conditions.RefName.Include = CleanSlice(conditions.RefName.Include)
+		conditions.RefName.Exclude = CleanSlice(conditions.RefName.Exclude)
+	}
+	if conditions.RepositoryName != nil {
+		conditions.RepositoryName.Include = CleanSlice(conditions.RepositoryName.Include)
+		conditions.RepositoryName.Exclude = CleanSlice(conditions.RepositoryName.Exclude)
+	}
 
 	if ShouldRemoveRepositoryName(conditions.RepositoryName) {
 		conditions.RepositoryName = nil


### PR DESCRIPTION
This pull request makes targeted improvements to how conditions are processed and cleaned in the ruleset import/export utilities. The changes ensure that `RefName` and `RepositoryName` fields are handled safely, preventing potential nil pointer issues and ensuring data consistency.

**Improvements to condition processing and cleaning:**

* Added a nil check for `RefName` before processing its `Include` and `Exclude` slices in `ProcessConditions`, preventing possible runtime errors.
* Updated `CleanConditions` to check for nil on both `RefName` and `RepositoryName` before cleaning their `Include` and `Exclude` slices, improving robustness and preventing nil pointer dereferences.

Closes: #14 