### PR TITLE
Add single repo migration rename

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/README.md
+++ b/README.md
@@ -162,7 +162,19 @@ Flags:
       --source-hostname string   GitHub Enterprise Server hostname where rulesets are copied from (default "github.com")
   -s, --source-org string        Name of the Source Organization to copy rulesets from
   -p, --source-pat string        GitHub personal access token for Source Organization (default "gh auth token")
+  -T, --target-repo string       Rename the destination repository when migrating a single repository's rulesets
   -t, --token string             GitHub personal access token for organization to write to (default "gh auth token")
+```
+
+When migrating a **single repository** with `--source-org`, use `--target-repo` to create the
+rulesets under a different repository name (a repository rename). This is useful when the
+destination repository has been renamed relative to the source. `--target-repo` requires exactly
+one repository via `--repos` and cannot be combined with `--from-file` (a file already contains the
+destination repository name).
+
+```sh
+# Rename during a single-repo migration from a source organization
+$ gh migrate-rulesets create target-org --source-org source-org --repos old-repo --target-repo new-repo
 ```
 
 If specifying `--source-org` and/or `--repos`, the CLI extension will attempt to map the object

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ The output `csv` file contains the following information:
 </details>
 <!-- markdownlint-enable MD013 -->
 
+> [!NOTE]
+> Fields within multi-value columns (e.g. `RulesBranchNamePattern`, `RulesCommitMessagePattern`)
+> are written in a stable, alphabetically-sorted order. This keeps exports deterministic so
+> re-running `list` produces byte-identical output for unchanged rulesets, making before/after
+> diffs reliable.
+
 ### Create Repository Rulesets
 
 Repository Rulesets can be created from a `csv` file using `--from-file` following the format outlined
@@ -189,6 +195,16 @@ based on name to the new ID under the target organization:
 - Required Workflow
   - Repository
 
+When the command finishes it logs a summary of how many rulesets were created successfully and how
+many failed, for example:
+
+```text
+Summary: 12 ruleset(s) created successfully, 2 failed
+```
+
 > [!NOTE]
-> If a ruleset fails to be created, a ruleset's Source, Name, and Error will be written to a `csv`
-> file in the current directory with the name format `<org>-ruleset-errors-<date>.csv`.
+> Any ruleset that fails to be created is captured and written to a `csv` file in the current
+> directory with the name format `<org>-ruleset-errors-<date>.csv`, containing the `Source`,
+> `RulesetName`, and `Error`. This includes per-ruleset creation failures as well as failures to
+> fetch organization or repository rulesets from the source (recorded with a `RulesetName` of
+> `N/A`), so all issues are available for easy review.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ The output `csv` file contains the following information:
 <table>
 <tr><th>Field Name</th><th>Description</th></tr>
 <tr><td><code>RulesetLevel</code></td><td>Indicates whether the ruleset is at the organization or repository level.</td></tr>
-<tr><td><code>RepositoryName</code></td><td>If repository level ruleset, the name of the repository where the data is extracted from. For Organization rulesets, this is <code>N/A</code>.</td></tr>
+<tr><td><code>SourceRepositoryName</code></td><td>If repository level ruleset, the name of the repository where the data is extracted from. For Organization rulesets, this is <code>N/A</code>.</td></tr>
+<tr><td><code>TargetRepositoryName</code></td><td>The destination repository name used when creating rulesets with <code>--from-file</code>. Defaults to the same value as <code>SourceRepositoryName</code> on export; edit this column to rename the destination repository during a <code>--from-file</code> migration. For Organization rulesets, this is <code>N/A</code>.</td></tr>
 <tr><td><code>RuleID</code></td><td>Unique identifier for the rule.</td></tr>
 <tr><td><code>RulesetName</code></td><td>Name of the ruleset.</td></tr>
 <tr><td><code>Target</code></td><td>Indicates the type of ruleset, can be <code>branch</code>, <code>tag</code>, or <code>push</code>.</td></tr>
@@ -183,6 +184,13 @@ destination repository name).
 $ gh migrate-rulesets create target-org --source-org source-org --repos old-repo --target-repo new-repo
 ```
 
+When creating rulesets with `--from-file`, repository renames are driven by the CSV itself. Each
+repository-level row carries both a `SourceRepositoryName` and a `TargetRepositoryName` column. On
+export these values are identical; edit `TargetRepositoryName` to create the ruleset under a
+different destination repository. If `TargetRepositoryName` is empty, the destination defaults to
+`SourceRepositoryName`. Files exported by earlier versions that only contain a `RepositoryName`
+column remain supported and are treated as the source (and target) repository name.
+
 If specifying `--source-org` and/or `--repos`, the CLI extension will attempt to map the object
 based on name to the new ID under the target organization:
 
@@ -205,6 +213,9 @@ Summary: 12 ruleset(s) created successfully, 2 failed
 > [!NOTE]
 > Any ruleset that fails to be created is captured and written to a `csv` file in the current
 > directory with the name format `<org>-ruleset-errors-<date>.csv`, containing the `Source`,
-> `RulesetName`, and `Error`. This includes per-ruleset creation failures as well as failures to
-> fetch organization or repository rulesets from the source (recorded with a `RulesetName` of
-> `N/A`), so all issues are available for easy review.
+> `RulesetName`, and `Error`. `Source` is where creation was attempted: for repository-level
+> rulesets it is in `org/repo` format (reflecting any `--target-repo` or `TargetRepositoryName`
+> rename), and for organization-level rulesets it is the organization name. This includes
+> per-ruleset creation failures as well as failures to fetch organization or repository rulesets
+> from the source (recorded with a `RulesetName` of `N/A`), so all issues are available for easy
+> review.

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -25,6 +25,7 @@ type cmdFlags struct {
 	hostname       string
 	fileName       string
 	repos          []string
+	targetRepo     string
 	ruleType       string
 	debug          bool
 }
@@ -43,6 +44,14 @@ func NewCmdCreate() *cobra.Command {
 				return errors.New("a file or source organization must be specified where rulesets will be created from")
 			} else if len(cmdFlags.fileName) > 0 && len(cmdFlags.sourceOrg) > 0 {
 				return errors.New("specify only one of `--source-organization` or `from-file`")
+			}
+			if len(cmdFlags.targetRepo) > 0 {
+				if len(cmdFlags.fileName) > 0 {
+					return errors.New("`--target-repo` cannot be used with `--from-file`; the file already contains the destination repository name")
+				}
+				if len(cmdFlags.repos) != 1 {
+					return errors.New("`--target-repo` requires exactly one repository via `--repos`")
+				}
 			}
 			return nil
 		},
@@ -76,6 +85,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().StringVarP(&cmdFlags.sourceHostname, "source-hostname", "", "github.com", "GitHub Enterprise Server hostname where rulesets are copied from")
 	createCmd.Flags().StringVarP(&cmdFlags.fileName, "from-file", "f", "", "Path and Name of CSV file to create rulesets from")
 	createCmd.Flags().StringSliceVarP(&cmdFlags.repos, "repos", "R", []string{}, "List of repositories names to recreate rulesets for separated by commas (i.e. repo1,repo2,repo3)")
+	createCmd.Flags().StringVarP(&cmdFlags.targetRepo, "target-repo", "T", "", "Rename the destination repository when migrating a single repository's rulesets")
 	createCmd.PersistentFlags().StringVarP(&cmdFlags.ruleType, "ruleType", "r", ruleDefault, "List rulesets for a specific application or all: {all|repoOnly|orgOnly}")
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
 
@@ -90,6 +100,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 	var sourceOrgID int
 	var importRepoRulesetsList []data.RepoRuleset
 	var errorRulesets []data.ErrorRulesets
+	successCount := 0
 
 	zap.S().Infof("Reading in file %s to identify repository rulesets", cmdFlags.fileName)
 	if len(cmdFlags.fileName) > 0 {
@@ -147,6 +158,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 						return nil
 					}
 					zap.S().Infof("Successfully create repository ruleset %s for %s", ruleset.Name, owner)
+					successCount++
 				case "Repository":
 					zap.S().Debugf("Trying to create repository rulesets under %s", ruleset.Source)
 					exists := g.RepoExists(ruleset.Source)
@@ -169,6 +181,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 						return nil
 					}
 					zap.S().Infof("Successfully create repository ruleset %s for %s", ruleset.Name, ruleset.Source)
+					successCount++
 				}
 				return nil
 			}, fmt.Sprintf("creating ruleset %s for %s", ruleset.Name, ruleset.Source))
@@ -192,6 +205,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 				allOrgRules, err := s.FetchOrgRulesets(sourceOrg)
 				if err != nil {
 					zap.S().Errorf("Error raised in fetching org ruleset data for %s", sourceOrg)
+					errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: sourceOrg, RulesetName: "N/A", Error: fmt.Sprintf("failed to fetch organization rulesets: %v", err)})
 				}
 				for _, singleRule := range allOrgRules {
 					execErr := utils.SafeExecute(func() error {
@@ -236,6 +250,8 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 							zap.S().Infof("Error creating ruleset %s for %s: %s", sourceOrg, createRuleset.Name, errorValidation)
 							return nil
 						}
+						zap.S().Infof("Successfully created organization ruleset %s for %s", createRuleset.Name, owner)
+						successCount++
 						return nil
 					}, fmt.Sprintf("creating org ruleset %s", singleRule.Name))
 					if execErr != nil {
@@ -252,7 +268,8 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 					allRepoRules, err := g.FetchRepoRulesets(sourceOrg, allRepos)
 					if err != nil {
 						zap.S().Error("Error raised in fetching repo ruleset data", zap.Error(err))
-						return err
+						errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: sourceOrg, RulesetName: "N/A", Error: fmt.Sprintf("failed to fetch repository rulesets: %v", err)})
+						allRepoRules = nil
 					}
 					for _, singleRepoRule := range allRepoRules {
 						execErr := utils.SafeExecute(func() error {
@@ -293,6 +310,10 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 								return nil
 							}
 							repoName := sourceParts[1]
+							if len(cmdFlags.targetRepo) > 0 {
+								zap.S().Infof("Migrating rulesets from %s to %s", repoName, cmdFlags.targetRepo)
+								repoName = cmdFlags.targetRepo
+							}
 							zap.S().Debugf("Creating rulesets under %s/%s", owner, repoName)
 							newSource := fmt.Sprintf("%s/%s", owner, repoName)
 							exists := g.RepoExists(newSource)
@@ -314,6 +335,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 								return nil
 							}
 							zap.S().Infof("Successfully created repository ruleset %s for %s", singleRepoRule.Rule.Name, newSource)
+							successCount++
 							return nil
 						}, fmt.Sprintf("creating repo ruleset %s for %s", singleRepoRule.Rule.Name, singleRepoRule.RepoName))
 						if execErr != nil {
@@ -343,5 +365,6 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 	} else {
 		zap.S().Infof("Completed list of rulesets in org %s", owner)
 	}
+	zap.S().Infof("Summary: %d ruleset(s) created successfully, %d failed", successCount, len(errorRulesets))
 	return nil
 }

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -43,7 +43,7 @@ func NewCmdCreate() *cobra.Command {
 			if len(cmdFlags.fileName) == 0 && len(cmdFlags.sourceOrg) == 0 {
 				return errors.New("a file or source organization must be specified where rulesets will be created from")
 			} else if len(cmdFlags.fileName) > 0 && len(cmdFlags.sourceOrg) > 0 {
-				return errors.New("specify only one of `--source-organization` or `from-file`")
+				return errors.New("specify only one of `--source-org` or `--from-file`")
 			}
 			if len(cmdFlags.targetRepo) > 0 {
 				if len(cmdFlags.fileName) > 0 {
@@ -160,27 +160,34 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 					zap.S().Infof("Successfully create repository ruleset %s for %s", ruleset.Name, owner)
 					successCount++
 				case "Repository":
-					zap.S().Debugf("Trying to create repository rulesets under %s", ruleset.Source)
-					exists := g.RepoExists(ruleset.Source)
+					destSource := ruleset.Source
+					if ruleset.TargetSource != "" {
+						destSource = ruleset.TargetSource
+					}
+					if destSource != ruleset.Source {
+						zap.S().Infof("Migrating rulesets from %s to %s", ruleset.Source, destSource)
+					}
+					zap.S().Debugf("Trying to create repository rulesets under %s", destSource)
+					exists := g.RepoExists(destSource)
 					if !exists {
-						zap.S().Debugf("Repository %s does not exist", ruleset.Source)
-						errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: ruleset.Source, RulesetName: createRuleset.Name, Error: "Repository does not exist"})
-						zap.S().Infof("Error creating ruleset %s for %s: %s", ruleset.Source, createRuleset.Name, "Repository does not exist")
+						zap.S().Debugf("Repository %s does not exist", destSource)
+						errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: destSource, RulesetName: createRuleset.Name, Error: "Repository does not exist"})
+						zap.S().Infof("Error creating ruleset %s for %s (source repo %s): %s", createRuleset.Name, destSource, ruleset.Source, "Repository does not exist")
 						return nil
 					}
-					zap.S().Debugf("Creating rulesets under %s", ruleset.Source)
-					err = g.CreateRepoLevelRuleset(ruleset.Source, reader)
+					zap.S().Debugf("Creating rulesets under %s", destSource)
+					err = g.CreateRepoLevelRuleset(destSource, reader)
 					if err != nil {
 						if strings.Contains(err.Error(), "\n") {
 							errorValidation = strings.Split(err.Error(), "\n")[1]
 						} else {
 							errorValidation = err.Error()
 						}
-						errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: ruleset.Source, RulesetName: createRuleset.Name, Error: errorValidation})
-						zap.S().Infof("Error creating ruleset %s for %s: %s", ruleset.Source, createRuleset.Name, errorValidation)
+						errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: destSource, RulesetName: createRuleset.Name, Error: errorValidation})
+						zap.S().Infof("Error creating ruleset %s for %s (source repo %s): %s", createRuleset.Name, destSource, ruleset.Source, errorValidation)
 						return nil
 					}
-					zap.S().Infof("Successfully create repository ruleset %s for %s", ruleset.Name, ruleset.Source)
+					zap.S().Infof("Successfully create repository ruleset %s for %s", ruleset.Name, destSource)
 					successCount++
 				}
 				return nil
@@ -319,8 +326,8 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 							exists := g.RepoExists(newSource)
 							if !exists {
 								zap.S().Debugf("Repository %s does not exist in %s", repoName, owner)
-								errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: repoLevelRuleset.Source, RulesetName: createRuleset.Name, Error: "Repository does not exist"})
-								zap.S().Infof("Error creating ruleset %s for %s: %s", repoLevelRuleset.Source, createRuleset.Name, "Repository does not exist")
+								errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: newSource, RulesetName: createRuleset.Name, Error: "Repository does not exist"})
+								zap.S().Infof("Error creating ruleset %s for %s (source repo %s): %s", createRuleset.Name, newSource, repoLevelRuleset.Source, "Repository does not exist")
 								return nil
 							}
 							err = g.CreateRepoLevelRuleset(newSource, reader)
@@ -330,8 +337,8 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g utils.Getter, s utils.Gett
 								} else {
 									errorValidation = err.Error()
 								}
-								errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: repoLevelRuleset.Source, RulesetName: createRuleset.Name, Error: errorValidation})
-								zap.S().Infof("Error creating ruleset %s for %s: %s", repoLevelRuleset.Source, createRuleset.Name, errorValidation)
+								errorRulesets = append(errorRulesets, data.ErrorRulesets{Source: newSource, RulesetName: createRuleset.Name, Error: errorValidation})
+								zap.S().Infof("Error creating ruleset %s for %s (source repo %s): %s", createRuleset.Name, newSource, repoLevelRuleset.Source, errorValidation)
 								return nil
 							}
 							zap.S().Infof("Successfully created repository ruleset %s for %s", singleRepoRule.Rule.Name, newSource)

--- a/cmd/create/create_test.go
+++ b/cmd/create/create_test.go
@@ -13,12 +13,15 @@ import (
 )
 
 type MockAPIGetter struct {
-	ShouldError      bool
-	RepoExistsResult bool
-	OrgRulesets      []data.Rulesets
-	RepoRulesets     []data.RepoNameRule
-	Repos            []data.RepoInfo
-	OrgID            int
+	ShouldError            bool
+	RepoExistsResult       bool
+	OrgRulesets            []data.Rulesets
+	RepoRulesets           []data.RepoNameRule
+	Repos                  []data.RepoInfo
+	OrgID                  int
+	CreatedRepoSources     []string
+	FetchOrgRulesetsError  bool
+	FetchRepoRulesetsError bool
 }
 
 func (m *MockAPIGetter) CreateOrgLevelRuleset(owner string, data io.Reader) error {
@@ -29,6 +32,7 @@ func (m *MockAPIGetter) CreateOrgLevelRuleset(owner string, data io.Reader) erro
 }
 
 func (m *MockAPIGetter) CreateRepoLevelRuleset(ownerRepo string, data io.Reader) error {
+	m.CreatedRepoSources = append(m.CreatedRepoSources, ownerRepo)
 	if m.ShouldError {
 		return errors.New("mock error creating repo ruleset")
 	}
@@ -80,14 +84,14 @@ func (m *MockAPIGetter) FetchOrgId(owner string) (*data.OrgIdQuery, error) {
 }
 
 func (m *MockAPIGetter) FetchOrgRulesets(owner string) ([]data.Rulesets, error) {
-	if m.ShouldError {
+	if m.ShouldError || m.FetchOrgRulesetsError {
 		return nil, errors.New("mock error fetching org rulesets")
 	}
 	return m.OrgRulesets, nil
 }
 
 func (m *MockAPIGetter) FetchRepoRulesets(owner string, repos []data.RepoInfo) ([]data.RepoNameRule, error) {
-	if m.ShouldError {
+	if m.ShouldError || m.FetchRepoRulesetsError {
 		return nil, errors.New("mock error fetching repo rulesets")
 	}
 	return m.RepoRulesets, nil
@@ -268,6 +272,24 @@ func TestCmdCreate_PreRunE(t *testing.T) {
 			wantErr:    true,
 			errMessage: "specify only one of",
 		},
+		{
+			name:       "target-repo with multiple repos",
+			args:       []string{"--source-org", "testorg", "--repos", "repo1,repo2", "--target-repo", "renamed"},
+			wantErr:    true,
+			errMessage: "requires exactly one repository",
+		},
+		{
+			name:       "target-repo with source-org but no repos",
+			args:       []string{"--source-org", "testorg", "--target-repo", "renamed"},
+			wantErr:    true,
+			errMessage: "requires exactly one repository",
+		},
+		{
+			name:       "target-repo with from-file",
+			args:       []string{"--from-file", "test.csv", "--target-repo", "renamed"},
+			wantErr:    true,
+			errMessage: "cannot be used with `--from-file`",
+		},
 	}
 
 	for _, tt := range tests {
@@ -416,5 +438,104 @@ func TestRunCmdCreate_FromSourceOrg(t *testing.T) {
 				t.Errorf("runCmdCreate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestRunCmdCreate_FromSourceOrg_TargetRepoRename(t *testing.T) {
+	mockGetter := &MockAPIGetter{
+		RepoExistsResult: true,
+		Repos:            []data.RepoInfo{{DatabaseId: 10, Name: "repo1"}},
+		RepoRulesets: []data.RepoNameRule{
+			{RepoName: "repo1", Rule: data.Rulesets{ID: "R_2", DatabaseID: 2, Name: "repo-ruleset"}},
+		},
+	}
+	mockSource := &MockAPIGetter{OrgID: 123}
+
+	flags := &cmdFlags{
+		sourceOrg:  "source-org",
+		ruleType:   "repoOnly",
+		repos:      []string{"repo1"},
+		targetRepo: "renamed-repo",
+	}
+
+	if err := runCmdCreate("target-org", flags, mockGetter, mockSource); err != nil {
+		t.Fatalf("runCmdCreate() unexpected error = %v", err)
+	}
+
+	want := "target-org/renamed-repo"
+	found := false
+	for _, source := range mockGetter.CreatedRepoSources {
+		if source == want {
+			found = true
+		}
+		if source == "target-org/repo1" {
+			t.Errorf("repo-level ruleset created against original repo %q, expected rename to %q", source, want)
+		}
+	}
+	if !found {
+		t.Errorf("expected repo-level ruleset created against %q, got %v", want, mockGetter.CreatedRepoSources)
+	}
+}
+
+// readErrorCSV finds and reads the most recent error CSV written for owner in cwd.
+func readErrorCSV(t *testing.T, owner string) string {
+	t.Helper()
+	matches, err := filepath.Glob(owner + "-ruleset-errors-*.csv")
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected an error CSV file for owner %q, none found", owner)
+	}
+	t.Cleanup(func() {
+		for _, m := range matches {
+			_ = os.Remove(m)
+		}
+	})
+	content, err := os.ReadFile(matches[len(matches)-1])
+	if err != nil {
+		t.Fatalf("failed to read error CSV: %v", err)
+	}
+	return string(content)
+}
+
+func TestRunCmdCreate_FetchOrgRulesetsError_WrittenToCSV(t *testing.T) {
+	mockGetter := &MockAPIGetter{}
+	mockSource := &MockAPIGetter{OrgID: 123, FetchOrgRulesetsError: true}
+
+	flags := &cmdFlags{
+		sourceOrg: "fetch-org-fail",
+		ruleType:  "orgOnly",
+	}
+
+	if err := runCmdCreate("fetch-org-fail", flags, mockGetter, mockSource); err != nil {
+		t.Fatalf("runCmdCreate() unexpected error = %v", err)
+	}
+
+	content := readErrorCSV(t, "fetch-org-fail")
+	if !strings.Contains(content, "failed to fetch organization rulesets") {
+		t.Errorf("error CSV missing org rulesets fetch failure, got:\n%s", content)
+	}
+}
+
+func TestRunCmdCreate_FetchRepoRulesetsError_WrittenToCSV(t *testing.T) {
+	mockGetter := &MockAPIGetter{
+		Repos:                  []data.RepoInfo{{DatabaseId: 10, Name: "repo1"}},
+		FetchRepoRulesetsError: true,
+	}
+	mockSource := &MockAPIGetter{OrgID: 123}
+
+	flags := &cmdFlags{
+		sourceOrg: "fetch-repo-fail",
+		ruleType:  "repoOnly",
+	}
+
+	if err := runCmdCreate("fetch-repo-fail", flags, mockGetter, mockSource); err != nil {
+		t.Fatalf("runCmdCreate() unexpected error = %v", err)
+	}
+
+	content := readErrorCSV(t, "fetch-repo-fail")
+	if !strings.Contains(content, "failed to fetch repository rulesets") {
+		t.Errorf("error CSV missing repo rulesets fetch failure, got:\n%s", content)
 	}
 }

--- a/cmd/create/create_test.go
+++ b/cmd/create/create_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/katiem0/gh-migrate-rulesets/internal/data"
 	"github.com/katiem0/gh-migrate-rulesets/internal/utils"
@@ -547,7 +548,19 @@ func readErrorCSV(t *testing.T, owner string) string {
 			_ = os.Remove(m)
 		}
 	})
-	content, err := os.ReadFile(matches[len(matches)-1])
+	newest := matches[0]
+	var newestMod time.Time
+	for _, m := range matches {
+		info, err := os.Stat(m)
+		if err != nil {
+			t.Fatalf("failed to stat error CSV %q: %v", m, err)
+		}
+		if info.ModTime().After(newestMod) {
+			newest = m
+			newestMod = info.ModTime()
+		}
+	}
+	content, err := os.ReadFile(newest)
 	if err != nil {
 		t.Fatalf("failed to read error CSV: %v", err)
 	}

--- a/cmd/create/create_test.go
+++ b/cmd/create/create_test.go
@@ -22,6 +22,7 @@ type MockAPIGetter struct {
 	CreatedRepoSources     []string
 	FetchOrgRulesetsError  bool
 	FetchRepoRulesetsError bool
+	RepoRulesetsFromFile   []data.RepoRuleset
 }
 
 func (m *MockAPIGetter) CreateOrgLevelRuleset(owner string, data io.Reader) error {
@@ -44,6 +45,9 @@ func (m *MockAPIGetter) RepoExists(ownerRepo string) bool {
 }
 
 func (m *MockAPIGetter) CreateRepoRulesetsData(owner string, fileData [][]string) []data.RepoRuleset {
+	if m.RepoRulesetsFromFile != nil {
+		return m.RepoRulesetsFromFile
+	}
 	return []data.RepoRuleset{
 		{
 			ID:           1,
@@ -311,9 +315,9 @@ func TestCmdCreate_PreRunE(t *testing.T) {
 }
 
 func TestRunCmdCreate_FromFile(t *testing.T) {
-	csvContent := `RulesetLevel,RepositoryName,RuleID,RulesetName,Target,Enforcement,BypassActors,ConditionsRefNameInclude,ConditionsRefNameExclude,ConditionsRepoNameInclude,ConditionsRepoNameExclude,ConditionsRepoNameProtected,ConditionRepoPropertyInclude,ConditionRepoPropertyExclude,RulesCreation,RulesUpdate,RulesDeletion,RulesRequiredLinearHistory,RulesMergeQueue,RulesRequiredDeployments,RulesRequiredSignatures,RulesPullRequest,RulesRequiredStatusChecks,RulesNonFastForward,RulesCommitMessagePattern,RulesCommitAuthorEmailPattern,RulesCommitterEmailPattern,RulesBranchNamePattern,RulesTagNamePattern,RulesFilePathRestriction,RulesFilePathLength,RulesFileExtensionRestriction,RulesMaxFileSize,RulesWorkflows,RulesCodeScanning,CreatedAt,UpdatedAt
-Organization,N/A,1,org-level-ruleset,branch,active,,,,,,,,,true,,,,,,,,,,,,,,,,,,,,,2023-01-01T00:00:00Z,2023-01-01T00:00:00Z
-Repository,test-repo,2,repo-level-ruleset,branch,active,,,,,,,,,,true,,,,,,,,,,,,,,,,,,,,2023-01-01T00:00:00Z,2023-01-01T00:00:00Z`
+	csvContent := `RulesetLevel,SourceRepositoryName,TargetRepositoryName,RuleID,RulesetName,Target,Enforcement,BypassActors,ConditionsRefNameInclude,ConditionsRefNameExclude,ConditionsRepoNameInclude,ConditionsRepoNameExclude,ConditionsRepoNameProtected,ConditionRepoPropertyInclude,ConditionRepoPropertyExclude,RulesCreation,RulesUpdate,RulesDeletion,RulesRequiredLinearHistory,RulesMergeQueue,RulesRequiredDeployments,RulesRequiredSignatures,RulesPullRequest,RulesRequiredStatusChecks,RulesNonFastForward,RulesCommitMessagePattern,RulesCommitAuthorEmailPattern,RulesCommitterEmailPattern,RulesBranchNamePattern,RulesTagNamePattern,RulesFilePathRestriction,RulesFilePathLength,RulesFileExtensionRestriction,RulesMaxFileSize,RulesWorkflows,RulesCodeScanning,CreatedAt,UpdatedAt
+Organization,N/A,N/A,1,org-level-ruleset,branch,active,,,,,,,,,true,,,,,,,,,,,,,,,,,,,,,2023-01-01T00:00:00Z,2023-01-01T00:00:00Z
+Repository,test-repo,test-repo,2,repo-level-ruleset,branch,active,,,,,,,,,,true,,,,,,,,,,,,,,,,,,,,2023-01-01T00:00:00Z,2023-01-01T00:00:00Z`
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.csv")
 	if err != nil {
@@ -380,6 +384,57 @@ Repository,test-repo,2,repo-level-ruleset,branch,active,,,,,,,,,,true,,,,,,,,,,,
 				t.Errorf("runCmdCreate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestRunCmdCreate_FromFile_TargetRepositoryRename(t *testing.T) {
+	csvContent := `RulesetLevel,SourceRepositoryName,TargetRepositoryName,RuleID,RulesetName,Target,Enforcement,RulesPullRequest,CreatedAt,UpdatedAt
+Repository,old-repo,new-repo,2,repo-level-ruleset,branch,active,,2023-01-01T00:00:00Z,2023-01-01T00:00:00Z`
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmpFile.Write([]byte(csvContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	mockGetter := &MockAPIGetter{
+		RepoExistsResult: true,
+		RepoRulesetsFromFile: []data.RepoRuleset{
+			{
+				ID:           2,
+				Name:         "repo-level-ruleset",
+				Target:       "branch",
+				SourceType:   "Repository",
+				Source:       "testorg/old-repo",
+				TargetSource: "testorg/new-repo",
+				Enforcement:  "active",
+				BypassActors: []data.BypassActor{},
+				Conditions:   &data.Conditions{},
+				Rules:        []data.Rules{{Type: "deletion"}},
+			},
+		},
+	}
+
+	if err := runCmdCreate("testorg", &cmdFlags{fileName: tmpFile.Name()}, mockGetter, mockGetter); err != nil {
+		t.Fatalf("runCmdCreate() error = %v", err)
+	}
+
+	found := false
+	for _, src := range mockGetter.CreatedRepoSources {
+		if src == "testorg/new-repo" {
+			found = true
+		}
+		if src == "testorg/old-repo" {
+			t.Errorf("ruleset was created under source repo testorg/old-repo, expected target testorg/new-repo")
+		}
+	}
+	if !found {
+		t.Errorf("ruleset was not created under target repo testorg/new-repo, got %v", mockGetter.CreatedRepoSources)
 	}
 }
 
@@ -537,5 +592,40 @@ func TestRunCmdCreate_FetchRepoRulesetsError_WrittenToCSV(t *testing.T) {
 	content := readErrorCSV(t, "fetch-repo-fail")
 	if !strings.Contains(content, "failed to fetch repository rulesets") {
 		t.Errorf("error CSV missing repo rulesets fetch failure, got:\n%s", content)
+	}
+}
+
+func TestRunCmdCreate_TargetRepoRename_ErrorRecordsDestination(t *testing.T) {
+	// Target repo does not exist, so creation fails and should be recorded with
+	// the destination repo (org/repo format) where creation was attempted.
+	mockGetter := &MockAPIGetter{
+		RepoExistsResult: false,
+		Repos:            []data.RepoInfo{{DatabaseId: 10, Name: "repo1"}},
+		RepoRulesets: []data.RepoNameRule{
+			{RepoName: "repo1", Rule: data.Rulesets{ID: "R_2", DatabaseID: 2, Name: "repo-ruleset"}},
+		},
+	}
+	mockSource := &MockAPIGetter{OrgID: 123}
+
+	flags := &cmdFlags{
+		sourceOrg:  "rename-fail",
+		ruleType:   "repoOnly",
+		repos:      []string{"repo1"},
+		targetRepo: "new-repo",
+	}
+
+	if err := runCmdCreate("rename-fail", flags, mockGetter, mockSource); err != nil {
+		t.Fatalf("runCmdCreate() unexpected error = %v", err)
+	}
+
+	content := readErrorCSV(t, "rename-fail")
+	if !strings.Contains(content, "Source,RulesetName,Error") {
+		t.Errorf("error CSV missing expected headers, got:\n%s", content)
+	}
+	if !strings.Contains(content, "rename-fail/new-repo,") {
+		t.Errorf("error CSV missing destination repo in Source column, got:\n%s", content)
+	}
+	if !strings.Contains(content, "Repository does not exist") {
+		t.Errorf("error CSV missing failure reason, got:\n%s", content)
 	}
 }

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -137,7 +137,8 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g ListGetter, 
 
 	headers := []string{
 		"RulesetLevel",
-		"RepositoryName",
+		"SourceRepositoryName",
+		"TargetRepositoryName",
 		"RuleID",
 		"RulesetName",
 		"Target",
@@ -207,6 +208,7 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g ListGetter, 
 					zap.S().Debugf("Writing CSV row for org ruleset: %s", singleRule.Name)
 					row := []string{
 						orgLevelRuleset.SourceType,
+						"N/A",
 						"N/A",
 						strconv.Itoa(orgLevelRuleset.ID),
 						orgLevelRuleset.Name,
@@ -305,6 +307,7 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g ListGetter, 
 						owner, singleRepoRule.RepoName, singleRepoRule.Rule.Name)
 					repoRow := []string{
 						repoLevelRuleset.SourceType,
+						singleRepoRule.RepoName,
 						singleRepoRule.RepoName,
 						strconv.Itoa(repoLevelRuleset.ID),
 						repoLevelRuleset.Name,

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -265,6 +265,9 @@ func TestRunCmdList(t *testing.T) {
 					if !strings.Contains(contentStr, "RulesetLevel") {
 						t.Error("Output file missing expected CSV headers")
 					}
+					if !strings.Contains(contentStr, "SourceRepositoryName") || !strings.Contains(contentStr, "TargetRepositoryName") {
+						t.Error("Output file missing SourceRepositoryName/TargetRepositoryName headers")
+					}
 				}
 			}
 

--- a/internal/data/rules.go
+++ b/internal/data/rules.go
@@ -55,6 +55,7 @@ type RepoRuleset struct {
 	Target       string        `json:"target"`
 	SourceType   string        `json:"source_type"`
 	Source       string        `json:"source"`
+	TargetSource string        `json:"-"`
 	Enforcement  string        `json:"enforcement"`
 	BypassActors []BypassActor `json:"bypass_actors"`
 	Conditions   *Conditions   `json:"conditions"`

--- a/internal/utils/exportruleset.go
+++ b/internal/utils/exportruleset.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -128,9 +129,14 @@ func (g *APIGetter) ProcessRules(rules []data.Rules) map[string]string {
 			rulesMap[rule.Type] = "true"
 		} else {
 			parametersMap := g.ParametersToMap(*rule.Parameters, rule.Type)
+			keys := make([]string, 0, len(parametersMap))
+			for key := range parametersMap {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
 			var formattedParams []string
-			for key, value := range parametersMap {
-				formattedParams = append(formattedParams, fmt.Sprintf("%s:%v", key, value))
+			for _, key := range keys {
+				formattedParams = append(formattedParams, fmt.Sprintf("%s:%v", key, parametersMap[key]))
 			}
 			if len(formattedParams) > 0 {
 				rulesMap[rule.Type] = strings.Join(formattedParams, "|")

--- a/internal/utils/exportruleset_test.go
+++ b/internal/utils/exportruleset_test.go
@@ -248,6 +248,32 @@ func TestProcessRules(t *testing.T) {
 	}
 }
 
+func TestProcessRulesStableFieldOrder(t *testing.T) {
+	g := &APIGetter{}
+
+	rules := []data.Rules{
+		{
+			Type: "branch_name_pattern",
+			Parameters: &data.Parameters{
+				Name:     "Hotfixes must be merged in master first",
+				Negate:   true,
+				Operator: "starts_with",
+				Pattern:  "hotfix/",
+			},
+		},
+	}
+
+	want := "Name:Hotfixes must be merged in master first|Negate:true|Operator:starts_with|Pattern:hotfix/"
+
+	// Run repeatedly to catch non-deterministic map iteration order.
+	for i := 0; i < 50; i++ {
+		got := g.ProcessRules(rules)
+		if got["branch_name_pattern"] != want {
+			t.Fatalf("ProcessRules() branch_name_pattern = %q, want %q (iteration %d)", got["branch_name_pattern"], want, i)
+		}
+	}
+}
+
 func TestProcessActorsForExport(t *testing.T) {
 	g := &APIGetter{}
 

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -194,6 +194,13 @@ func TestWriteErrorRulesetsToCSV(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error with repo-level source",
+			errorRulesets: []data.ErrorRulesets{
+				{Source: "target-org/new-repo", RulesetName: "rename-ruleset", Error: "Repository does not exist"},
+			},
+			wantErr: false,
+		},
+		{
 			name:          "empty error list",
 			errorRulesets: []data.ErrorRulesets{},
 			wantErr:       false,
@@ -234,6 +241,9 @@ func TestWriteErrorRulesetsToCSV(t *testing.T) {
 				for _, errorRuleset := range tt.errorRulesets {
 					if !strings.Contains(contentStr, errorRuleset.RulesetName) {
 						t.Errorf("CSV file missing ruleset %s", errorRuleset.RulesetName)
+					}
+					if errorRuleset.RulesetName != "" && !strings.Contains(contentStr, errorRuleset.Source+",") {
+						t.Errorf("CSV file missing Source %q", errorRuleset.Source)
 					}
 				}
 			}

--- a/internal/utils/importruleset.go
+++ b/internal/utils/importruleset.go
@@ -24,7 +24,9 @@ func (g *APIGetter) CreateRepoRulesetsData(owner string, fileData [][]string) []
 		repoRuleset.Name = each[headerMap["RulesetName"]]
 		repoRuleset.Target = each[headerMap["Target"]]
 		repoRuleset.SourceType = each[headerMap["RulesetLevel"]]
-		repoRuleset.Source = determineSource(owner, each[headerMap["RulesetLevel"]], each[headerMap["RepositoryName"]])
+		sourceRepo, targetRepo := repoNamesFromRow(each, headerMap)
+		repoRuleset.Source = determineSource(owner, each[headerMap["RulesetLevel"]], sourceRepo)
+		repoRuleset.TargetSource = determineSource(owner, each[headerMap["RulesetLevel"]], targetRepo)
 		repoRuleset.Enforcement = each[headerMap["Enforcement"]]
 		repoRuleset.BypassActors = g.ParseBypassActorsForImport(owner, each[headerMap["BypassActors"]])
 		repoRuleset.Conditions = parseConditions(each[headerMap["ConditionsRefNameInclude"] : headerMap["ConditionRepoPropertyExclude"]+1])
@@ -41,6 +43,25 @@ func (g *APIGetter) CreateRepoRulesetsData(owner string, fileData [][]string) []
 		importRepoRuleset = append(importRepoRuleset, repoRuleset)
 	}
 	return importRepoRuleset
+}
+
+// repoNamesFromRow returns the source and target repository names for a CSV row.
+// It reads SourceRepositoryName (falling back to the legacy RepositoryName header
+// for backward compatibility) and TargetRepositoryName. When TargetRepositoryName
+// is missing or empty, the target defaults to the source repository name.
+func repoNamesFromRow(each []string, headerMap map[string]int) (source, target string) {
+	sourceIdx, ok := headerMap["SourceRepositoryName"]
+	if !ok {
+		sourceIdx, ok = headerMap["RepositoryName"]
+	}
+	if ok && sourceIdx < len(each) {
+		source = each[sourceIdx]
+	}
+	target = source
+	if idx, ok := headerMap["TargetRepositoryName"]; ok && idx < len(each) && each[idx] != "" {
+		target = each[idx]
+	}
+	return source, target
 }
 
 func determineSource(owner, sourceType, repoName string) string {

--- a/internal/utils/importruleset_test.go
+++ b/internal/utils/importruleset_test.go
@@ -555,13 +555,13 @@ func TestParseRules(t *testing.T) {
 func TestCreateRepoRulesetsData(t *testing.T) {
 	g := &APIGetter{}
 	header := []string{
-		"RulesetLevel", "RepositoryName", "RuleID", "RulesetName", "Target", "Enforcement", "BypassActors",
+		"RulesetLevel", "SourceRepositoryName", "TargetRepositoryName", "RuleID", "RulesetName", "Target", "Enforcement", "BypassActors",
 		"ConditionsRefNameInclude", "ConditionsRefNameExclude", "ConditionsRepoNameInclude",
 		"ConditionsRepoNameExclude", "ConditionsRepoNameProtected", "ConditionRepoPropertyInclude",
 		"ConditionRepoPropertyExclude", "RulesPullRequest", "CreatedAt", "UpdatedAt",
 	}
 	row := []string{
-		"Organization", "N/A", "1", "test-ruleset", "branch", "active", "",
+		"Organization", "N/A", "N/A", "1", "test-ruleset", "branch", "active", "",
 		"main", "", "", "", "false", "", "",
 		"DismissStaleReviewsOnPush:true|RequiredApprovingReviewCount:2",
 		"2023-01-01T00:00:00Z", "2023-01-02T00:00:00Z",
@@ -581,5 +581,63 @@ func TestCreateRepoRulesetsData(t *testing.T) {
 	}
 	if len(rs.Rules) != 1 || rs.Rules[0].Type != "pull_request" {
 		t.Errorf("CreateRepoRulesetsData() Rules = %+v, want one pull_request rule", rs.Rules)
+	}
+}
+
+func TestCreateRepoRulesetsData_TargetRepositoryRename(t *testing.T) {
+	g := &APIGetter{}
+	header := []string{
+		"RulesetLevel", "SourceRepositoryName", "TargetRepositoryName", "RuleID", "RulesetName", "Target", "Enforcement", "BypassActors",
+		"ConditionsRefNameInclude", "ConditionsRefNameExclude", "ConditionsRepoNameInclude",
+		"ConditionsRepoNameExclude", "ConditionsRepoNameProtected", "ConditionRepoPropertyInclude",
+		"ConditionRepoPropertyExclude", "RulesPullRequest", "CreatedAt", "UpdatedAt",
+	}
+	row := []string{
+		"Repository", "old-repo", "new-repo", "2", "repo-ruleset", "branch", "active", "",
+		"main", "", "", "", "false", "", "",
+		"",
+		"2023-01-01T00:00:00Z", "2023-01-02T00:00:00Z",
+	}
+	fileData := [][]string{header, row}
+
+	got := g.CreateRepoRulesetsData("testorg", fileData)
+	if len(got) != 1 {
+		t.Fatalf("CreateRepoRulesetsData() returned %d rulesets, want 1", len(got))
+	}
+	rs := got[0]
+	if rs.Source != "testorg/old-repo" {
+		t.Errorf("CreateRepoRulesetsData() Source = %q, want testorg/old-repo", rs.Source)
+	}
+	if rs.TargetSource != "testorg/new-repo" {
+		t.Errorf("CreateRepoRulesetsData() TargetSource = %q, want testorg/new-repo", rs.TargetSource)
+	}
+}
+
+func TestCreateRepoRulesetsData_LegacyRepositoryNameHeader(t *testing.T) {
+	g := &APIGetter{}
+	header := []string{
+		"RulesetLevel", "RepositoryName", "RuleID", "RulesetName", "Target", "Enforcement", "BypassActors",
+		"ConditionsRefNameInclude", "ConditionsRefNameExclude", "ConditionsRepoNameInclude",
+		"ConditionsRepoNameExclude", "ConditionsRepoNameProtected", "ConditionRepoPropertyInclude",
+		"ConditionRepoPropertyExclude", "RulesPullRequest", "CreatedAt", "UpdatedAt",
+	}
+	row := []string{
+		"Repository", "legacy-repo", "3", "repo-ruleset", "branch", "active", "",
+		"main", "", "", "", "false", "", "",
+		"",
+		"2023-01-01T00:00:00Z", "2023-01-02T00:00:00Z",
+	}
+	fileData := [][]string{header, row}
+
+	got := g.CreateRepoRulesetsData("testorg", fileData)
+	if len(got) != 1 {
+		t.Fatalf("CreateRepoRulesetsData() returned %d rulesets, want 1", len(got))
+	}
+	rs := got[0]
+	if rs.Source != "testorg/legacy-repo" {
+		t.Errorf("CreateRepoRulesetsData() Source = %q, want testorg/legacy-repo", rs.Source)
+	}
+	if rs.TargetSource != "testorg/legacy-repo" {
+		t.Errorf("CreateRepoRulesetsData() TargetSource = %q, want testorg/legacy-repo (defaults to source)", rs.TargetSource)
 	}
 }


### PR DESCRIPTION
This pull request adds support for repository renaming during ruleset migrations, improves error reporting and summary output, and clarifies documentation for the new and existing features. The changes ensure that users can reliably migrate rulesets to a differently named target repository, and that both the CLI and CSV workflows are intuitive and robust. Comprehensive tests have been added to cover the new validation logic.

**Repository migration and renaming:**

* Added a `--target-repo` flag to the `create` command, allowing users to rename the destination repository when migrating rulesets for a single repository. This is validated to only work with one repository and not with `--from-file`. [[1]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R28) [[2]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8L45-R54) [[3]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R88)
* Updated the migration logic to use the new target repository name wherever appropriate, including logging and error reporting. [[1]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R161-R191) [[2]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R320-R330)
* Extended CSV-based migrations to support both `SourceRepositoryName` and `TargetRepositoryName` columns, enabling repository renames via CSV edits. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R193)

**Error handling and reporting:**

* Improved error collection: all failures to create rulesets (including fetch errors) are now written to an error CSV with clear source and error context, and the command logs a summary of successes and failures at the end. [[1]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R215) [[2]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R260-R261) [[3]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8L255-R279) [[4]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8R375) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R206-R221)

**Documentation updates:**

* Updated the `README.md` to document the new flags, CSV columns, and migration workflows, including detailed explanations, usage examples, and notes on deterministic CSV output for easier diffing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R133-R138) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R193) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R206-R221)

**Testing improvements:**

* Added and extended tests for the new validation logic and repository renaming behavior, including error cases for invalid flag combinations. [[1]](diffhunk://#diff-3ad4b7e606ddb55acc8d52e91c8df56656549a7eae93eb2fb8f7a31fa948ce6bR23-R26) [[2]](diffhunk://#diff-3ad4b7e606ddb55acc8d52e91c8df56656549a7eae93eb2fb8f7a31fa948ce6bR37) [[3]](diffhunk://#diff-3ad4b7e606ddb55acc8d52e91c8df56656549a7eae93eb2fb8f7a31fa948ce6bR49-R51) [[4]](diffhunk://#diff-3ad4b7e606ddb55acc8d52e91c8df56656549a7eae93eb2fb8f7a31fa948ce6bL83-R99) [[5]](diffhunk://#diff-3ad4b7e606ddb55acc8d52e91c8df56656549a7eae93eb2fb8f7a31fa948ce6bR280-R297)

**Maintenance:**

* Updated the GitHub Actions workflow to use the latest `setup-go` action version (`v7.0.0`).